### PR TITLE
Relate more "unknown" goals, Add important_goals & graphs classes!

### DIFF
--- a/Change-log.txt
+++ b/Change-log.txt
@@ -1,3 +1,11 @@
+------ Version 1.10.0 ------
+    "Solved" many goals without owner, carry them from the parsing time and trying to relate them after all the game is parsed.
+    Allow more date formats as inputs.
+    Fix competitions names for maccabipedia.
+    Add 'ErrorsFinder' class to find errors (run manually).
+    Add Important goals statistics! (maccabi_games_stats.important_goals).
+    Add Graphs! (maccabi_games_stats.graphs).
+
 ------ Version 1.9.1 ------
     Read readme.md file as utf-8
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ after that you can just load the games:
 
 ```
 from maccabistats import get_maccabi_stats
-games = get_maccabi_stats(youre_maccabi.games_file_path)  # Use the local path you've downloaded the file from mega.
+games = get_maccabi_stats(your_maccabi.games_file_path)  # Use the local path you've downloaded the file from mega.
 ```
 
 You might want to use:

--- a/maccabistats/__init__.py
+++ b/maccabistats/__init__.py
@@ -3,6 +3,6 @@ from .maccabilogging import initialize_logging
 # This should stays first to enable logging across all package
 initialize_logging()
 
-from .stats.serialized_games import serialize_maccabi_games, get_maccabi_stats
+from .stats.serialized_games import serialize_maccabi_games, get_maccabi_stats, get_maccabi_stats_as_newest_wrapper
 from .maccabilogging import faster_logging
 from maccabistats.data_improvement.manual_fixes import run_manual_fixes

--- a/maccabistats/config/settings.ini
+++ b/maccabistats/config/settings.ini
@@ -5,5 +5,5 @@ folder-to-save-seasons-html-files = c:\maccabi\seasons
 folder-to-save-games-html-files = c:\maccabi\games
 use-disk-to-crawl-when-available = True
 use-lxml-parser = True
-use_multi-process-crawl = True
+use_multi-process-crawl = False
 crawling-processes-number = 10

--- a/maccabistats/data_improvement/fix_specific_games.py
+++ b/maccabistats/data_improvement/fix_specific_games.py
@@ -7,7 +7,7 @@ logger = logging.getLogger(__name__)
 
 
 def __fix_basel_three_three(games):
-    against_basel_tie_three = games.get_games_against_team("באזל").played_after("06.08.2013").played_before("06.08.2013")
+    against_basel_tie_three = games.get_games_against_team("באזל").played_after("2013-08-06").played_before("2013-08-06")
     against_basel_tie_three = against_basel_tie_three[0]
     if against_basel_tie_three.not_maccabi_team.scored_players[0].events[2].goal_type is not GoalTypes.OWN_GOAL:
         against_basel_tie_three.not_maccabi_team.scored_players[0].events[2].goal_type = GoalTypes.OWN_GOAL
@@ -15,7 +15,7 @@ def __fix_basel_three_three(games):
 
 
 def __fix_haifa_three_one(games):
-    against_haifa_three_one_win = games.get_games_against_team("מכבי חיפה").played_after("20.10.2014").played_before("20.10.2014")
+    against_haifa_three_one_win = games.get_games_against_team("מכבי חיפה").played_after("2014-10-20").played_before("2014-10-20")
     against_haifa_three_one_win = against_haifa_three_one_win[0]
     if against_haifa_three_one_win.not_maccabi_team.scored_players[0].events[1].goal_type is not GoalTypes.OWN_GOAL:
         against_haifa_three_one_win.not_maccabi_team.scored_players[0].events[1].goal_type = GoalTypes.OWN_GOAL
@@ -23,7 +23,7 @@ def __fix_haifa_three_one(games):
 
 
 def __fix_hibernians_five_one(games):
-    against_hibernians_five_one_win = games.get_games_against_team("היברניאנס").played_after("21.07.2015").played_before("21.07.2015")
+    against_hibernians_five_one_win = games.get_games_against_team("היברניאנס").played_after("2015-07-21").played_before("2015-07-21")
     against_hibernians_five_one_win = against_hibernians_five_one_win[0]
     if against_hibernians_five_one_win.not_maccabi_team.scored_players[1].events[1].goal_type is not GoalTypes.OWN_GOAL:
         against_hibernians_five_one_win.not_maccabi_team.scored_players[1].events[1].goal_type = GoalTypes.OWN_GOAL
@@ -31,7 +31,7 @@ def __fix_hibernians_five_one(games):
 
 
 def __fix_akko_two_zero(games):
-    against_akko_two_zero_win = games.get_games_against_team("הפועל עכו").played_after("20.10.2012").played_before("20.10.2012")
+    against_akko_two_zero_win = games.get_games_against_team("הפועל עכו").played_after("2012-10-20").played_before("2012-10-20")
     against_akko_two_zero_win = against_akko_two_zero_win[0]
     if against_akko_two_zero_win.not_maccabi_team.scored_players[0].events[1].goal_type is not GoalTypes.OWN_GOAL:
         against_akko_two_zero_win.not_maccabi_team.scored_players[0].events[1].goal_type = GoalTypes.OWN_GOAL
@@ -39,13 +39,18 @@ def __fix_akko_two_zero(games):
 
 
 def __fix_beitar_three_two(games):
-    against_beitar_three_two_win = games.get_games_against_team('בית"ר ירושלים').played_after("17.05.2003").played_before("17.05.2003")
+    against_beitar_three_two_win = games.get_games_against_team('בית"ר ירושלים').played_after("2003-05-17").played_before("2003-05-17")
     against_beitar_three_two_win = against_beitar_three_two_win[0]
     david = [p for p in against_beitar_three_two_win.not_maccabi_team.players if p.name == "דוד אמסלם"][0]
     if not david.scored:
         goal = GameEvent(GameEventTypes.GOAL_SCORE, timedelta(minutes=33))
         david.add_event(goal)
         logger.info("Fixed דוד אמסלם goal - probably does not exists after crawling maccabi-tlv site( appear in events page but not in squads page.")
+
+    if against_beitar_three_two_win._half_parsed_events:
+        logger.info("Removing half parsed goals events from this game ({date}".format(date=against_beitar_three_two_win.date))
+        against_beitar_three_two_win._half_parsed_events = list(
+            filter(lambda event: event['event_type'] != GameEventTypes.GOAL_SCORE, against_beitar_three_two_win._half_parsed_events))
 
 
 def fix_specific_games(games):

--- a/maccabistats/data_improvement/manual_fixes.py
+++ b/maccabistats/data_improvement/manual_fixes.py
@@ -1,4 +1,5 @@
 from maccabistats.data_improvement.fix_specific_games import fix_specific_games
+from maccabistats.models.player_game_events import GameEventTypes, GoalGameEvent
 
 import logging
 
@@ -34,6 +35,18 @@ _players_name_fixes = [("מיקו בלו", ["מנחם 'מיקו' בלו"]),
                        ("גונסאלו גארסיה", ["גונזאלו גארסיה"]),
                        ]
 
+# The format is like players above.
+_competitions_name_fixes = [("גביע אירופה למחזיקות גביע", ["גביע אירופה למחזיקות"]),
+                            ("מוקדמות הליגה האירופית", ["מוקדמות ליגה אירופית"]),
+                            ("גביע אסיה לאלופות", ["גביע אסיה"]),
+                            ("פלייאוף הליגה האירופית", ["פלייאוף אירופה ליג"]),
+                            ("גביע אופא", ['גביע אופ"א']),
+                            ("הליגה האירופית", ["ליגה אירופית"]),
+                            ("ליגת העל", ["ליגת Winner"]),
+                            ("ליגה לאומית", ["ליגת לאומית"]),
+                            ("ליגה א", ["ליגה א'"]),
+                            ]
+
 
 def __fix_opponents_names(game):
     if game.not_maccabi_team.name == "עירוני קרית שמונה":
@@ -49,9 +62,10 @@ def __fix_referees_names(game):
 
 
 def __fix_competitions_names(game):
-    if game.competition == "ליגת לאומית":
-        game.competition = "ליגה לאומית"
-        logger.info("ליגת לאומית->ליגה לאומית")
+    for competition_best_name, competition_similar_name in _competitions_name_fixes:
+        if game.competition in competition_similar_name:
+            logger.info("Changing competition name from :{old}-->{new}".format(old=game.competition, new=competition_best_name))
+            game.competition = competition_best_name
 
 
 def __fix_maccabi_players_names(game):
@@ -62,7 +76,6 @@ def __fix_maccabi_players_names(game):
                 player.name = player_best_name
 
 
-# TODO fix that in crawling
 def __fix_seasons(game):
     """
     Remove ' - ' from season and replace it with ' / '.
@@ -71,6 +84,97 @@ def __fix_seasons(game):
     if "-" in game.season:
         logger.info("Replacing '-' with '/' in game season")
         game.season = game.season.replace('-', '/')
+
+
+def __fix_half_parsed_goal_events(game):
+    half_parsed_goals = [event for event in game._half_parsed_events if event['event_type'] == GameEventTypes.GOAL_SCORE]
+    if not half_parsed_goals:
+        return
+
+    total_score = game.maccabi_team.score + game.not_maccabi_team.score
+    total_goal_events = len(game.goals())
+
+    if total_score != total_goal_events:
+        logger.info("Found game (date-{date}) with "
+                    "total score of: {total_score}, total goals events: {total_goal_events} and total half parsed goals: {total_half_parsed_goals}"
+                    .format(date=game.date, total_score=total_score, total_goal_events=total_goal_events,
+                            total_half_parsed_goals=len(half_parsed_goals)))
+    else:
+        logger.warning("Total score & total goals events are equals "
+                       "but game (date-{date}) got {num} half parsed goals.".format(date=game.date, num=len(half_parsed_goals)))
+
+    if total_goal_events + len(half_parsed_goals) <= total_score:
+        logger.info("Half parsed goal events seems to missing goals, Adding them!")
+        __add_half_parsed_goals_events_to_game(game, half_parsed_goals)
+    else:
+        logger.warning("Half parsed goals + total goals events does not equal to the total score, something wrong, do nothing.")
+
+
+def __get_player_for_half_parsed_goals_events(game, goal_event):
+    """
+    Trying to search for exact name, after that for first\last name, after that splitting name by dot (if exist) and search for first\last name.
+    """
+    # Trying to find player with the exact name.
+    name = goal_event['name']
+    all_players = game.maccabi_team.players + game.not_maccabi_team.players
+    players = [player for player in all_players if player.name == name]
+    if players:
+        return players[0]
+
+    # Trying to find player with the same first\last name.
+    logger.info("Cant find full player name, trying first\last name:{name}".format(name=name))
+    players = [player for player in all_players if name in player.name.split()]
+    if players:
+        return players[0]
+
+    # Trying dot pattern, like : א.זוהר which might be איציק זוהר
+    logger.info("Cant find first\last player name, trying check for dot pattern name:{name}".format(name=name))
+    if "." in name:
+        first, last = [part.strip() for part in name.split(".")]
+        players = [player for player in all_players if last in player.name.split()]
+        # If we found two players with the same last name, try with the first name.
+        if len(players) > 1:
+            players = [player for player in players if player.name.startswith(first)]
+
+        if players:
+            return players[0]
+
+    return None
+
+
+def __add_half_parsed_goals_events_to_game(game, half_parsed_goals_events):
+    event_to_delete_from_game_half_parsed_event = []
+
+    for event in half_parsed_goals_events:
+        if not event['name']:
+            logger.warning("Found goal (game date - {date}) with empty player name, skipping".format(date=game.date))
+            continue
+
+        player_for_this_event = __get_player_for_half_parsed_goals_events(game, event)
+        if player_for_this_event is None:
+            logger.warning("Could not find any player that match somehow to this name:{name}, skipping this event".format(name=event['name']))
+            continue
+
+        logger.info("Add goal event: {event} to this player:{name} in this game date: {date}"
+                    .format(event=event, name=player_for_this_event.name, date=game.date))
+
+        goal_event = GoalGameEvent(event['time_occur'], event['goal_type'])
+        player_for_this_event.add_event(goal_event)
+        event_to_delete_from_game_half_parsed_event.append(event)
+
+    if event_to_delete_from_game_half_parsed_event:
+        logger.info("Removing half parsed goals events from this game")
+        new_half_parsed_events = [not_added_half_parsed_event for not_added_half_parsed_event in half_parsed_goals_events if
+                                  not_added_half_parsed_event not in event_to_delete_from_game_half_parsed_event]
+        game._half_parsed_events = new_half_parsed_events
+
+
+def __remove_youth_games(maccabi_games_stats):
+    # TODO: remove this when we start manipulating youth statistics
+    YOUTH_COMPETITIONS = ['גביע המדינה לנוער', 'ליגת העל לנוער']
+    logger.info("Removing youth games if exists:(")
+    return maccabi_games_stats.create_maccabi_stats_from_games(
+        [game for game in maccabi_games_stats.games if game.competition not in YOUTH_COMPETITIONS])
 
 
 def run_manual_fixes(maccabi_games_stats):
@@ -86,7 +190,13 @@ def run_manual_fixes(maccabi_games_stats):
         __fix_competitions_names(game)
         __fix_maccabi_players_names(game)
         __fix_seasons(game)
+        # ATM, only the important events = goals.
+        try:
+            __fix_half_parsed_goal_events(game)
+        except LookupError:
+            logger.exception("Error while parsing goals half parsed events.")
 
+    maccabi_games_stats = __remove_youth_games(maccabi_games_stats)
     fix_specific_games(maccabi_games_stats)
 
     return maccabi_games_stats

--- a/maccabistats/error_finder/error_finder.py
+++ b/maccabistats/error_finder/error_finder.py
@@ -1,0 +1,68 @@
+from maccabistats.models.player_game_events import GameEventTypes
+
+from itertools import chain
+import logging
+from datetime import timedelta
+
+logger = logging.getLogger(__name__)
+""" This class responsible to find errors in maccabigamesstats object, such as games that the amount of goals does not match to the final score sum,
+    empty events and so on.
+
+    This should be run manually.
+"""
+
+
+class ErrorsFinder(object):
+    """ Each public function on this class wil lbe run automatically by 'get_all_errors_numbers'. """
+    def __init__(self, maccabi_games_stats):
+        """
+        :type maccabi_games_stats: maccabistats.stats.maccabi_games_stats.MaccabiGamesStats
+        """
+        self.maccabi_games_stats = maccabi_games_stats
+
+    def get_games_without_11_players_on_lineup(self):
+        """ Each team should has 11 players with lineup event! """
+
+        missing_lineup_games = [game for game in self.maccabi_games_stats
+                                if 11 > len(game.not_maccabi_team.lineup_players) or 11 > len(game.maccabi_team.lineup_players)]
+
+        return missing_lineup_games
+
+    def get_lineup_players_with_substitution_in(self):
+        """ Players that opened on lineup, should'nt has substitution in event. """
+
+        players = [player for game in self.maccabi_games_stats for player in game.maccabi_team.players + game.not_maccabi_team.players
+                   if player.has_event_type(GameEventTypes.LINE_UP) and player.has_event_type(GameEventTypes.SUBSTITUTION_IN)]
+
+        return players
+
+    def get_games_with_missing_goals_events(self):
+        """ Total score should be equals to the total goals event """
+
+        games = [game for game in self.maccabi_games_stats if game.maccabi_team.score + game.not_maccabi_team.score != len(game.goals())]
+
+        return games
+
+    def get_players_with_event_but_without_lineup_or_substitution(self):
+        """ Every player that has any event should has atleast lineup or substitution in event """
+
+        players = [player for game in self.maccabi_games_stats for player in game.maccabi_team.players + game.not_maccabi_team.players
+                   if len(player.events) > 0 and  # Got any event but no lineup or subs in
+                   not player.has_event_type(GameEventTypes.LINE_UP) and not player.has_event_type(GameEventTypes.SUBSTITUTION_IN)]
+        return players
+
+    def get_goals_scored_at_minute_zero(self):
+        zero_time = str(timedelta(0))
+        all_goals = list(chain.from_iterable([game.goals() for game in self.maccabi_games_stats]))
+        return list(filter(lambda g: g['time_occur'] == zero_time, all_goals))
+
+    def get_all_errors_numbers(self):
+        """ Iterate over all this class functions without this one, and summarize the results. """
+        errors_finders = [func for func in dir(self) if
+                          callable(getattr(self, func)) and func != "get_all_errors_numbers" and not func.startswith("_")]
+
+        for func_name in errors_finders:
+            error_finder_func = getattr(self, func_name)
+            logger.info("{func_name}: returned {count} items".format(func_name=func_name,
+                                                                     count=len(error_finder_func())))
+

--- a/maccabistats/models/team_in_game.py
+++ b/maccabistats/models/team_in_game.py
@@ -82,7 +82,7 @@ class TeamInGame(Team):
         :rtype: Counter
         """
 
-        return Counter({player: condition(player) for player in self.players if
+        return Counter({player.name: condition(player) for player in self.players if
                         condition(player) > 0})
 
     @property
@@ -136,7 +136,7 @@ class TeamInGame(Team):
         :rtype: Counter
         """
         # Return counter of 1 of all played players in game
-        return Counter({player: 1 for player in self.played_players})
+        return Counter({player.name : 1 for player in self.played_players})
 
     def event_type_to_property_of_most_common_players(self, event_type):
         """

--- a/maccabistats/parse/maccabi_tlv_site/game_events_parser.py
+++ b/maccabistats/parse/maccabi_tlv_site/game_events_parser.py
@@ -19,6 +19,14 @@ class ComplicatedEventException(Exception):
     pass
 
 
+class TooManySameEventsException(Exception):
+    pass
+
+
+class FoundNoMatchingPlayersByNameException(Exception):
+    pass
+
+
 class MaccabiSiteGameEventsParser(object):
     """
     This class is responsible to parse the events from events page and add events that could not be added with squads page, like:
@@ -32,12 +40,14 @@ class MaccabiSiteGameEventsParser(object):
     others might be bug in maccabi site.
     """
 
-    def __init__(self, maccabi_team, not_maccabi_team, bs_content):
+    def __init__(self, maccabi_team, not_maccabi_team, bs_content, game_link):
         """
         There are 3 divs for each team ordered as: lineup_players, bench_players, coach.
         :type bs_content: bs4.element.Tag
         :type maccabi_team: maccabistats.models.team_in_game.TeamInGame
         :type not_maccabi_team: maccabistats.models.team_in_game.TeamInGame
+        :param game_link: the maccabi-tlv game link, for debugging.
+        :type game_link: str
         """
 
         logger.info("Parsing maccabi-{opponent}".format(opponent=not_maccabi_team.name))
@@ -45,6 +55,10 @@ class MaccabiSiteGameEventsParser(object):
         self.bs_content = bs_content
         self.maccabi_team = maccabi_team
         self.not_maccabi_team = not_maccabi_team
+        self.game_link = game_link
+        # We will save all the parsed events without matching events in squads page, to allow manipulate this data later.
+        self.halfed_parsed_events = []
+
         self.events_bs_content_list = self.bs_content.select("article div.play-by-play-homepage ul.play-by-play li")
 
         # TODO - this should be oneliner
@@ -81,7 +95,7 @@ class MaccabiSiteGameEventsParser(object):
             except ComplicatedEventException as e:
                 logger.info("ComplicatedEventException : {details}".format(details=str(e)))
             except CantFindEventException:
-                logger.exception("\nError parsing {event} at {event_time} from events page".format(event=event_text, event_time=event_time_in_minute))
+                logger.warning("\nError parsing {event} at {event_time} from events page".format(event=event_text, event_time=event_time_in_minute))
             except Exception:
                 logger.exception(
                     "\nUnknown error while parsing {event} at {event_time} from event page".format(event=event_text, event_time=event_time_in_minute))
@@ -105,11 +119,39 @@ class MaccabiSiteGameEventsParser(object):
         if len(players) > 1:
             logger.warning("Found more than 1 player named :{player_name}".format(player_name=player_name))
         elif len(players) == 0:
-            raise Exception("Game link : {link}\n"
-                            "Cant find player with that name : {name}".format(link=self.maccabi_team.game_link,
-                                                                              name=player_name))
+            raise FoundNoMatchingPlayersByNameException("Game link : {link}\n"
+                                                        "Cant find player with that name : {name}".format(link=self.game_link,
+                                                                                                          name=player_name))
 
-        return players[0]
+        # In case there are some players, we prefer the last, attack player is more likely to score\assist goal (those event are the important here).
+        return players[-1]
+
+    def __get_one_player_by_event_details(self, player_name, event):
+        """
+        Find one player that match the event details (event object + player name), that solve the case when two players has the same name.
+        The way to choose between them is by similarity to the given event.
+        :param player_name: the player name to search
+        :type player_name:str
+        :param event: the event to look for similar event on player events.
+        :type event: maccabistats.models.player_game_events.GameEvent
+        :return: PlayerInGame
+        """
+
+        player_name = normalize_name(player_name)
+        if len(player_name) > 20:
+            raise ComplicatedEventException(player_name)
+
+        players_events = [player.get_event_by_similar_event(event) for player in self.maccabi_team.players if player.name == player_name]
+        players_events.extend([player.get_event_by_similar_event(event) for player in self.not_maccabi_team.players if player.name == player_name])
+        players_events = list(filter(lambda e: e is not None, players_events))
+
+        if len(players_events) > 1:
+            logger.warning("Found more than 1 matching player events:{player_name}, event:{event}".format(player_name=player_name, event=event))
+        elif len(players_events) == 0:
+            raise CantFindEventException("Game link : {link}\nCant find player event by given details, player name:{name}, event:{event}"
+                                         .format(link=self.game_link, name=player_name, event=event))
+
+        return players_events[0]
 
     def __get_player_event(self, player, event):
         """ Check whether the given player got event in specific time
@@ -118,15 +160,21 @@ class MaccabiSiteGameEventsParser(object):
         :rtype: maccabistats.models.player_game_events.GameEvent
         """
 
-        player_event = player.get_event_by_similar_event(event)
+        try:
+            player_event = player.get_event_by_similar_event(event)
+        except Exception as e:
+            raise TooManySameEventsException("Probably Found {player_name} more than 1 matching event.\n"
+                                             "    Game link : {link}\n"
+                                             "    Event : {event}\n"
+                                             "    Inner exception : {inner}".format(player_name=player.name,
+                                                                                    link=self.game_link,
+                                                                                    event=event,
+                                                                                    inner=str(e)))
 
         if not player_event:
-            raise CantFindEventException(
-                "Found {player_name} event in events page without matching event in squads page.\n"
-                "    Game link : {link}\n"
-                "    Event : {event}\n".format(player_name=player.name,
-                                               link=self.maccabi_team.game_link,
-                                               event=event))
+            raise CantFindEventException("Found {player_name} event in events page without matching event in squads page.\n"
+                                         "    Game link : {link}\n"
+                                         "    Event : {event}\n".format(player_name=player.name, link=self.game_link, event=event))
 
         return player_event
 
@@ -205,15 +253,25 @@ class MaccabiSiteGameEventsParser(object):
     def __handle_goal_event(self, event_text, event_time_in_minute):
         player_name, goal_event = MaccabiSiteGameEventsParser.__extract_goal_details(event_text, event_time_in_minute)
 
-        player = self.__find_one_player_with_name(player_name)
-        player_event = self.__get_player_event(player, goal_event)
+        try:
+            player_event = self.__get_one_player_by_event_details(player_name, goal_event)
 
-        # Add goal type:
-        if goal_event.goal_type is not GoalTypes.UNKNOWN:
-            player_event.goal_type = goal_event.goal_type
-            logger.info(
-                "Changed goal type to {goal_type} for player: {player}".format(goal_type=goal_event.goal_type,
-                                                                               player=player.name))
+            # Add goal type:
+            if goal_event.goal_type is not GoalTypes.UNKNOWN:
+                player_event.goal_type = goal_event.goal_type
+                logger.info(
+                    "Changed goal type to {goal_type} for player: {player}".format(goal_type=goal_event.goal_type,
+                                                                                   player=player_name))
+        except CantFindEventException:
+            # We should hope no name that belong to two players in the same game will be related to goal.
+            # by manually checking there are none (the above case takes care of them).
+            try:
+                player = self.__find_one_player_with_name(player_name)
+                player.add_event(goal_event)
+                logger.info("Added goal event for player: {player}".format(player=player.name))
+            except FoundNoMatchingPlayersByNameException:
+                logger.info("Adding event to half parsed event:{event}, for name:{name}".format(event=goal_event, name=player_name))
+                self.halfed_parsed_events.append(dict(name=player_name, **goal_event.__dict__))
 
     def __handle_yellow_card_event(self, event_text, event_time_in_minute):
         player_name = event_text.replace("כרטיס צהוב ל", "").strip()
@@ -221,7 +279,11 @@ class MaccabiSiteGameEventsParser(object):
 
         yellow_card_event = GameEvent(GameEventTypes.YELLOW_CARD, event_time_in_minute)
 
-        self.__get_player_event(player, yellow_card_event)
+        try:
+            self.__get_player_event(player, yellow_card_event)
+        except CantFindEventException:
+            player.add_event(yellow_card_event)
+            logger.info("Added yellow card event for player: {player}".format(player=player.name))
 
     def __handle_red_card_event(self, event_text, event_time_in_minute):
         player_name = event_text.replace("כרטיס אדום ל", "").strip()

--- a/maccabistats/parse/maccabi_tlv_site/game_squads_parser.py
+++ b/maccabistats/parse/maccabi_tlv_site/game_squads_parser.py
@@ -55,11 +55,10 @@ class MaccabiSiteGameSquadsParser(object):
                                                                                  not_maccabi_final_score)
 
         # Parse game events
-        # TODO - this is for debugging, should find better solution:
-        maccabi_team.game_link = not_maccabi_team.game_link = game_content_web_page
         events_bs_page_content = get_game_events_bs_by_link(game_content_web_page)
-        game_events_parser = MaccabiSiteGameEventsParser(maccabi_team, not_maccabi_team, events_bs_page_content)
+        game_events_parser = MaccabiSiteGameEventsParser(maccabi_team, not_maccabi_team, events_bs_page_content, game_content_web_page)
         maccabi_team, not_maccabi_team = game_events_parser.enrich_teams_with_events()
+        halfed_parsed_events = game_events_parser.halfed_parsed_events
 
         referee = normalize_name(MaccabiSiteGameSquadsParser.__get_referee(squads_bs_page_content))
         crowd = MaccabiSiteGameSquadsParser.__get_crowd(squads_bs_page_content)
@@ -67,7 +66,8 @@ class MaccabiSiteGameSquadsParser(object):
         home_team, away_team = (maccabi_team, not_maccabi_team) if is_maccabi_home_team else (
             not_maccabi_team, maccabi_team)
 
-        return GameData(competition, fixture, date, stadium, crowd, referee, home_team, away_team, is_maccabi_home_team, season_string)
+        return GameData(competition, fixture, date, stadium, crowd, referee, home_team, away_team, is_maccabi_home_team, season_string,
+                        halfed_parsed_events)
 
     @staticmethod
     def __get_fixture_if_exists(bs_content):

--- a/maccabistats/parse/parse_from_all_sites.py
+++ b/maccabistats/parse/parse_from_all_sites.py
@@ -43,6 +43,10 @@ def parse_maccabi_games_from_all_sites():
     maccabi_games_from_maccabi_tlv_site = get_parsed_maccabi_games_from_maccabi_site()
     maccabi_stats_games = MaccabiGamesStats(maccabi_games_from_maccabi_tlv_site)
 
-    maccabi_stats_games_after_manual_fixes = run_manual_fixes(maccabi_stats_games)
+    try:
+        maccabi_stats_games_after_manual_fixes = run_manual_fixes(maccabi_stats_games)
+    except Exception:
+        logger.exception("Could not finish the manual_fixed - you should run again standalone")
+        maccabi_stats_games_after_manual_fixes = maccabi_stats_games
 
     return maccabi_stats_games_after_manual_fixes

--- a/maccabistats/stats/graphs.py
+++ b/maccabistats/stats/graphs.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+
+import matplotlib.pyplot as plt
+from datetime import datetime, timedelta
+from collections import Counter
+
+
+# This class will handle all the graphs for maccabi games stats
+
+
+class MaccabiGamesGraphsStats(object):
+
+    def __init__(self, maccabi_games_stats):
+        """
+        :type maccabi_games_stats: maccabistats.stats.maccabi_games_stats.MaccabiGamesStats
+        """
+
+        self.maccabi_games_stats = maccabi_games_stats
+
+    @staticmethod
+    def _show_histogram_of_this_counter(data_counter):
+        x, y = zip(*sorted(data_counter.items()))
+        plt.plot(x, y)
+        plt.show()
+
+    @staticmethod
+    def _show_bar_charts_of_this_counter(data_counter):
+        x, y = zip(*sorted(data_counter.items()))
+        plt.bar(x, y, width=0.5)
+        plt.xticks(x)
+        plt.show()
+
+    def _get_all_goals_minutes_for_player(self, player_name):
+        player_goals = [goal for game in self.maccabi_games_stats.games for goal in game.goals() if goal['name'] == player_name]
+
+        def convert_timedelta_str_to_minutes(t):
+            full_datetime = datetime.strptime(t, "%H:%M:%S")
+            delta = timedelta(hours=full_datetime.hour, minutes=full_datetime.minute)
+            return int(delta.total_seconds() / 60)
+
+        player_goals = [convert_timedelta_str_to_minutes(goal['time_occur']) for goal in player_goals]
+        if not player_goals:
+            raise RuntimeError("Could not find any goals for this player, are you sure this is the player name : {name}?".format(name=player_name))
+
+        return player_goals
+
+    def goals_distribution_for_player(self, player_name):
+        """
+        Return ths distribution of the given player goals by minutes
+        """
+
+        return Counter(self._get_all_goals_minutes_for_player(player_name))
+
+    def show_histogram_for_player_goals(self, player_name):
+        goals = self.goals_distribution_for_player(player_name)
+
+        self._show_histogram_of_this_counter(goals)
+        return goals
+
+    def show_bar_chart_for_player_goals_by_thirds(self, player_name):
+        """
+        Show bar charts of player goals by thirds (0-30, 30-60, 60-90, 90-120)
+        """
+
+        all_goals_by_thirds = [int(goal_minute / 30) for goal_minute in self._get_all_goals_minutes_for_player(player_name)]
+        goals_by_thirds = Counter(all_goals_by_thirds)
+
+        self._show_bar_charts_of_this_counter(goals_by_thirds)
+        return goals_by_thirds

--- a/maccabistats/stats/important_goals.py
+++ b/maccabistats/stats/important_goals.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+
+from datetime import timedelta
+from collections import Counter
+
+
+# This class will handle all important goals statistics.
+
+
+class MaccabiGamesImportantGoalsStats(object):
+
+    def __init__(self, maccabi_games_stats):
+        """
+        :type maccabi_games_stats: maccabistats.stats.maccabi_games_stats.MaccabiGamesStats
+        """
+
+        self.maccabi_games_stats = maccabi_games_stats
+        self.games = maccabi_games_stats.games
+
+    def get_top_scorers_for_advantage(self):
+        """
+        Get all players who score goal that made maccabi the lead team AFTER the goal was scored.
+        """
+
+        return self.get_top_scorers(1, 1)
+
+    def get_top_scorers(self, minimum_diff_for_maccabi=-2, maximum_diff_for_maccabi=1, goal_condition=None):
+        if goal_condition is None:
+            goal_condition = lambda x: True
+
+        maccabi_goals = [goal for game in self.games for goal in game.goals() if goal['team'] == "מכבי תל אביב"]
+        maccabi_important_goals = [goal for goal in maccabi_goals
+                                   if (minimum_diff_for_maccabi <= goal['maccabi_score'] - goal['not_maccabi_score'] <= maximum_diff_for_maccabi)
+                                   and goal_condition(goal)]
+
+        important_goals_scorers_names = [goal['name'] for goal in maccabi_important_goals]
+        return Counter(important_goals_scorers_names).most_common()
+
+    def get_top_scorers_by_percentage_from_all_their_goals(self, minimum_diff_for_maccabi=-2, maximum_diff_for_maccabi=1, minimum_important_goals=10):
+        """
+        Return the important goals for each player from his total goals, only for those who scored at least (minimum_important_goals).
+        """
+
+        players_total_goals = Counter(dict(self.maccabi_games_stats.players.best_scorers))
+        players_important_goals = Counter(dict(self.get_top_scorers(minimum_diff_for_maccabi, maximum_diff_for_maccabi)))
+
+        best_players = Counter()
+        for player_name, total_goals_for_player in players_total_goals.items():
+            if players_important_goals[player_name] >= minimum_important_goals:
+                key_name = "{player} - {total_goals} goals".format(player=player_name, total_goals=total_goals_for_player)
+                best_players[key_name] = round(players_important_goals[player_name] / total_goals_for_player * 100, 2)
+
+        return best_players.most_common()
+
+    def get_top_players_for_goals_per_game(self, minimum_diff_for_maccabi=-2, maximum_diff_for_maccabi=1, minimum_games=10):
+        """
+        Return the important goals for each player from his total goals, only for those who played at least (minimum_games).
+        """
+
+        players_total_played = Counter(dict(self.maccabi_games_stats.players.most_played))
+        players_important_goals = Counter(dict(self.get_top_scorers(minimum_diff_for_maccabi, maximum_diff_for_maccabi)))
+
+        best_players = Counter()
+        for player_name, total_games_for_player in players_total_played.items():
+            if players_important_goals[player_name] >= minimum_games:
+                key_name = "{player} - {total_games} games".format(player=player_name, total_games=total_games_for_player)
+                best_players[key_name] = round(players_important_goals[player_name] / total_games_for_player, 2)
+
+        return best_players.most_common()
+
+    def get_top_scorers_in_last_minutes(self, minimum_diff_for_maccabi=-2, maximum_diff_for_maccabi=1, from_minute=75):
+        return self.get_top_scorers(minimum_diff_for_maccabi, maximum_diff_for_maccabi,
+                                    lambda g: g['time_occur'] > str(timedelta(minutes=from_minute)))

--- a/maccabistats/stats/maccabi_games_stats.py
+++ b/maccabistats/stats/maccabi_games_stats.py
@@ -8,9 +8,13 @@ from maccabistats.stats.averages import MaccabiGamesAverageStats
 from maccabistats.stats.referees import MaccabiGamesRefereesStats
 from maccabistats.stats.comebacks import MaccabiGamesComebacksStats
 from maccabistats.stats.seasons import MaccabiGamesSeasonsStats
-
 from maccabistats.stats.results import MaccabiGamesResultsStats
+from maccabistats.stats.important_goals import MaccabiGamesImportantGoalsStats
+from maccabistats.stats.graphs import MaccabiGamesGraphsStats
+
 from maccabistats.version import version as maccabistats_version
+
+from dateutil.parser import parse as datetime_parser
 
 
 class MaccabiGamesStats(object):
@@ -30,6 +34,8 @@ class MaccabiGamesStats(object):
         self.referees = MaccabiGamesRefereesStats(self)
         self.comebacks = MaccabiGamesComebacksStats(self)
         self.seasons = MaccabiGamesSeasonsStats(self)
+        self.important_goals = MaccabiGamesImportantGoalsStats(self)
+        self.graphs = MaccabiGamesGraphsStats(self)
 
         self.version = maccabistats_version
 
@@ -93,6 +99,18 @@ class MaccabiGamesStats(object):
         :rtype: MaccabiGamesStats
         """
         return MaccabiGamesStats([game for game in self.games if game.played_after(date)])
+
+    def played_at(self, date):
+        """
+        Currently checking just the: year & month & day.
+        :param date: datetime.datetime or str
+        :return: maccabistats.models.game_data.GameData
+        """
+
+        if type(date) is str:
+            date = datetime_parser(date).date()
+
+        return [game for game in self.games if game.date.date() == date]
 
     def get_games_by_competition(self, competition_types):
         """
@@ -209,7 +227,7 @@ class MaccabiGamesStats(object):
 
     def __getitem__(self, item):
         """
-        :rtype: MaccabiSiteGameParser
+        :rtype: maccabistats.models.game_data.GameData
         """
         return self.games[item]
 

--- a/maccabistats/stats/serialized_games.py
+++ b/maccabistats/stats/serialized_games.py
@@ -12,6 +12,14 @@ serialized_maccabi_games_file_path = os.path.join(serialized_maccabi_games_folde
                                                   serialized_maccabi_games_file_name)
 
 
+def get_maccabi_stats_as_newest_wrapper(file_name=serialized_maccabi_games_file_path):
+    """"
+    Returns the serialized file_name cast to the latest MaccabiGamesStats object, which means that newer functions can be used.
+    """
+
+    return MaccabiGamesStats(get_maccabi_stats(file_name).games)
+
+
 def get_maccabi_stats(file_name=serialized_maccabi_games_file_path):
     """
     :param file_name: pickled maccabi games (probably MaccabiGamesStats object).
@@ -22,7 +30,7 @@ def get_maccabi_stats(file_name=serialized_maccabi_games_file_path):
         raise RuntimeError("You should have maccabi.games serialized object, you can use maccabistats.serialize_maccabi_games() to do that.")
 
     with open(file_name, 'rb') as f:
-        return MaccabiGamesStats(pickle.load(f))
+        return pickle.load(f)
 
 
 def serialize_maccabi_games(file_name=serialized_maccabi_games_file_path):

--- a/maccabistats/test.py
+++ b/maccabistats/test.py
@@ -1,14 +1,13 @@
 # -*- coding: utf-8 -*-
 
 
-from maccabistats.stats.serialized_games import get_maccabi_stats, serialize_maccabi_games
-from maccabistats.maccabilogging import faster_logging
+from maccabistats import *
 
 if __name__ == "__main__":
-    # faster_logging()
-    g = get_maccabi_stats()
 
-    f = g.get_first_league_games()
-    total = f.streaks.get_similar_losses_streak_by_length(3)
-    b = total[1]
+    g = get_maccabi_stats_as_newest_wrapper()
+
+    b = g.graphs.goals_distribution_for_player("ערן זהבי")
+    print(b[0:10])
+
     a = 6

--- a/maccabistats/version.py
+++ b/maccabistats/version.py
@@ -1,1 +1,1 @@
-version = "1.9.1"
+version = "1.10.0"

--- a/setup.py
+++ b/setup.py
@@ -13,5 +13,7 @@ setup(
     install_requires=["setuptools==28.8.0",
                       "requests==2.18.4",
                       "beautifulsoup4==4.6.0",
-                      "lxml==4.1.1"]
+                      "lxml==4.1.1",
+                      "python-dateutil==2.7.2",
+                      "matplotlib==2.2.2"]
 )


### PR DESCRIPTION
Add half parsed goals events (#25)

* fix bug at get_maccabi_stats, the returned object was wrapped by the last one (seen this when the version was last always)

* moved game_link to events parser, and add exception when found too many events.

* Add half_parsed_events

* Add to game goals event that not related to any player, trying to add them at manual_fixes. Seems to solve ~40/80 games with goals issues.

version to 1.10

parsed dates with python-dateutil, added to req.txt

added fast played_at

added competition renames and changed dates due to dateutil parser time

Add error finder class, this dhould be run manually

Add Graphs & important Goals!

important_goals working! (half)

All Counters now have player name as key instead of player object.

Add goals per game for important goals and normal goals.

Add Graphs! (for goals atm)

typo

change log