### PR TITLE
Supports some maccabi games sources (Table & maccabitlv-site)

### DIFF
--- a/Change-log.txt
+++ b/Change-log.txt
@@ -1,3 +1,6 @@
+------ Version 2.0.0 ------
+    Supports table maccabi games source, combines all sources outputs to one maccabiGamesStats object (maccabitlv-site & table).
+
 ------ Version 1.10.1 ------
     Replaced mega.nz link
 

--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@ games = games.get_first_league_games()
 ```
 because there are not only league games.
 
-now, enjoy :)  
+now, enjoy :)
 
 # Manipulating maccabi statistics
 
   ### Loading games
 ```
 >>> from maccabistats import get_maccabi_stats
->>> games = get_maccabi_stats()  # From default file path (inside maccabistats package) when you use serialize_maccabi_games()
+>>> games = get_maccabi_stats()  # From default folder path (Home folder - %userprofile%)
 >>> games = get_maccabi_stats(r"C:\maccabi\maccabi.games")  # From local custom file path
 ```
 
@@ -113,7 +113,8 @@ When crawling maccabi games each page will be saved on your disk to allow optimi
 To serialize maccabi games (it might take some time), use:
 ```
 >>> from maccabistats import serialize_maccabi_games
->>> serialize_maccabi_games(file_name)  # Default file_name will be stored inside maccabistats package.
+    # The object will be serialized to home folder (%userprofile%) with its version and the current date.
+>>> serialize_maccabi_games(maccabi_games_stats_object)
 ```
 
 Manual-fixes will be run after crawling is finished and before serializing to disk.
@@ -126,18 +127,18 @@ BUT atm logging does not support multi-processing, so don't use that if you need
 
 There are some information that need to be fix manually.  
 When serializing maccabi games that done automatically.
-If you Add anything to run_manual_fixes, you can re-run it by:
+If you Add anything to run_general_fixes, you can re-run it by:
 ```
->>> from maccabistats import get_maccabi_stats, run_manual_fixes, serialize_maccabi_games
+>>> from maccabistats import get_maccabi_stats, run_general_fixes, serialize_maccabi_games
 >>> 
 >>> games = get_maccabi_stats()
->>> new_games = run_manual_fixes(games)
+>>> new_games = run_general_fixes(games)
 >>> serialize_maccabi_games(new_games)
 ```
 
 # Logging
 
-All of the log files will be saved at 'maccabistats-logs' folder under the user home folder (pathlib.Path.home())
+All of the log files will be saved at 'maccabistats\logs' folder under the user home folder (%userprofile%)
 There are several log files, each one has this pattern - maccabistats-{suffix}.log (at the mentioned folder): 
 
 * all - save all log levels
@@ -168,13 +169,9 @@ There are several log files, each one has this pattern - maccabistats-{suffix}.l
 
 Manual check for errors might be helpful, this is can be done by:
 ```
->>> from maccabistats import get_maccabi_stats, run_manual_fixes, serialize_maccabi_games
+>>> from maccabistats import get_maccabi_stats
 >>> from maccabistats.error_finder.error_finder import ErrorsFinder
 >>> games = get_maccabi_stats()
 >>> e = ErrorsFinder(games)
->>> e.get_all_errors_numbers  # run all the manual errors exists
+>>> e.get_all_errors_numbers()  # run all the manual errors exists
 ```
-
-# Versioning
-ATM minor version change 1.X.0 may indicate API CHANGES.
- 

--- a/maccabistats/__init__.py
+++ b/maccabistats/__init__.py
@@ -3,6 +3,7 @@ from .maccabilogging import initialize_logging
 # This should stays first to enable logging across all package
 initialize_logging()
 
-from .stats.serialized_games import serialize_maccabi_games, get_maccabi_stats, get_maccabi_stats_as_newest_wrapper
+from .stats.serialized_games import combine_maccabi_stats_sources, run_all_maccabi_stats_sources, get_maccabi_stats, \
+    get_maccabi_stats_as_newest_wrapper, serialize_maccabi_games
 from .maccabilogging import faster_logging
-from maccabistats.data_improvement.manual_fixes import run_manual_fixes
+from maccabistats.data_improvement.manual_fixes import run_general_fixes

--- a/maccabistats/maccabilogging.py
+++ b/maccabistats/maccabilogging.py
@@ -2,8 +2,8 @@ import logging
 from pathlib import Path
 import os
 
-log_root_folder_path = Path.home().as_posix()
-log_file_path_pattern = os.path.join(log_root_folder_path, "maccabistats-logs", "maccabistats-{suffix}.log")
+maccabistats_root_folder_path = Path.home().as_posix()
+log_file_path_pattern = os.path.join(maccabistats_root_folder_path, "maccabistats", "logs", "maccabistats-{suffix}.log")
 log_file_folder_path = os.path.dirname(log_file_path_pattern)
 
 if not os.path.isdir(log_file_folder_path):

--- a/maccabistats/models/game_data.py
+++ b/maccabistats/models/game_data.py
@@ -8,7 +8,7 @@ from maccabistats.models.player_game_events import GameEventTypes, GoalTypes
 
 class GameData(object):
     def __init__(self, competition, fixture, date_as_hebrew_string, stadium, crowd, referee, home_team, away_team,
-                 is_maccabi_home_team, season_string, half_parsed_events):
+                 is_maccabi_home_team, season_string, half_parsed_events, date=None):
         """
         :param competition: cup, league and so on.
         :type competition: str
@@ -24,12 +24,15 @@ class GameData(object):
         :type season_string: str
         :param half_parsed_events: events which had problem while parsing or validating, should be use for manipulating the game data later.
         :type half_parsed_events: list of dict
+        :param date: the date the game was played.
+        :type date: datetime.datetime
         """
 
         self.competition = competition
         self.fixture = fixture
+        #todo get this shit out of here
         self.date_as_hebrew_string = date_as_hebrew_string
-        self.date = self.__get_date_as_datetime()
+        self.date = self.__get_date_as_datetime() if date is None else date  # Leave only the year & month & day
         self.stadium = stadium
         self.crowd = crowd
         self.referee = referee

--- a/maccabistats/parse/maccabi_tlv_site/fix_specific_games.py
+++ b/maccabistats/parse/maccabi_tlv_site/fix_specific_games.py
@@ -1,5 +1,5 @@
 from maccabistats.models.player_game_events import GoalTypes, GameEvent, GameEventTypes
-from datetime import timedelta
+from datetime import timedelta, datetime
 
 import logging
 
@@ -53,9 +53,30 @@ def __fix_beitar_three_two(games):
             filter(lambda event: event['event_type'] != GameEventTypes.GOAL_SCORE, against_beitar_three_two_win._half_parsed_events))
 
 
+def __fix_hapoel_haifa_four_two_date_99_00(games):
+    # This game saved on maccabi-tlv site as against maccabi-haifa, that mistake, it should be against hapoel-haifa, round 18 for this season.
+    # The original date is: 2000-01-03 (yy-mm-dd).
+    against_hapoel_haifa = games.played_at("2000-03-01")
+    if len(against_hapoel_haifa) > 1:
+        logger.warning("Found more than one game that should be fixed at date : 2000-03-01, Taking the first.")
+
+    against_hapoel_haifa = against_hapoel_haifa[0]
+    against_hapoel_haifa.not_maccabi_team.name = "הפועל חיפה"
+    against_hapoel_haifa.date = datetime(year=2000, month=1, day=3)
+    logger.info("Changed the game at data: 2000-03-01 to be at date: 2000-01-03 and replaced the opponent name from הפועל חיפה to מכבי חיפה")
+
+
 def fix_specific_games(games):
+    # TODO separate to two diff function (or any another logic).
+
+    # Fix goals:
     __fix_basel_three_three(games)
     __fix_haifa_three_one(games)
     __fix_hibernians_five_one(games)
     __fix_akko_two_zero(games)
     __fix_beitar_three_two(games)
+
+    # Fix dates:
+    __fix_hapoel_haifa_four_two_date_99_00(games)
+
+    return games

--- a/maccabistats/parse/maccabi_tlv_site/maccabi_tlv_site_source.py
+++ b/maccabistats/parse/maccabi_tlv_site/maccabi_tlv_site_source.py
@@ -1,0 +1,35 @@
+from maccabistats.parse.maccabi_tlv_site.fix_specific_games import fix_specific_games
+from maccabistats.parse.maccabi_tlv_site.main_parser import get_parsed_maccabi_games_from_maccabi_site
+from maccabistats.parse.maccabistats_source import MaccabiStatsSource
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+"""
+Implement MaccabiStatsSource that crawl maccabi-tlv site.
+"""
+
+
+class MaccabiTlvSiteSource(MaccabiStatsSource):
+
+    def _rerun_source(self):
+        """
+        Parse the raw data and saves it on self.maccabi_games_stats
+        """
+
+        return get_parsed_maccabi_games_from_maccabi_site()
+
+    def run_specific_fixes(self):
+        """
+        Run any specific fixes for this source (such as error within the raw data).
+        """
+
+        if self.maccabi_games_stats is None:
+            raise RuntimeError("You should run parse_maccabi_games first")
+
+        logger.info("Running fix specific games for maccabi-tlv site source")
+        self.maccabi_games_stats = fix_specific_games(self.maccabi_games_stats)
+
+
+

--- a/maccabistats/parse/maccabistats_source.py
+++ b/maccabistats/parse/maccabistats_source.py
@@ -1,0 +1,97 @@
+from maccabistats.stats.maccabi_games_stats import MaccabiGamesStats
+from maccabistats.data_improvement.manual_fixes import run_general_fixes
+import logging
+import os
+import pickle
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+home_folder = Path.home().as_posix()
+serialized_sources_path_pattern = os.path.join(home_folder, "maccabistats", "sources", "{source_name}.games")
+
+"""
+This class is responsible to set the api for each maccabistats source, the common usage should be :
+
+m = MaccabiStatsSource("maccabi")
+m.parse_maccabi_games()
+m.run_general_fixes()
+m.run_specific_fixes()
+
+games = m.maccabi_games_stats
+"""
+
+
+class MaccabiStatsSource(object):
+    def __init__(self, name):
+        self.name = name
+        self.maccabi_games_stats = None
+        self._serialized_games_path = serialized_sources_path_pattern.format(source_name=self.name)
+
+    def parse_maccabi_games(self, without_rerunning=False):
+        """
+        Parse the raw data and saves it on self.maccabi_games_stats.
+
+        :param without_rerunning: whether this source should be rerun or just use the serialized object.
+        """
+
+        if os.path.isfile(self._serialized_games_path):
+            self.maccabi_games_stats = self._load_serialized_games()
+            return
+        elif without_rerunning:
+            raise RuntimeError("While parsing games without rerunning, could not find the serialized object at: {path}".format(
+                path=self._serialized_games_path))
+
+        logger.info("Starting to parse maccabi games from :{name}".format(name="maccabi-tlv site"))
+        parsed_games = self._rerun_source()
+        self.maccabi_games_stats = MaccabiGamesStats(parsed_games)
+        self._serialize_games()
+
+    def _rerun_source(self):
+        """
+        Parse the raw data and saves it on self.maccabi_games_stats
+        :return:
+        """
+
+        raise NotImplementedError()
+
+    def run_specific_fixes(self):
+        """
+        Run any specific fixes for this source (such as error within the raw data).
+        """
+
+        raise NotImplementedError()
+
+    def run_general_fixes(self):
+        """
+        Runs any general fixes that relevant for all sources (such as naming and so on).
+        """
+
+        if self.maccabi_games_stats is None:
+            raise RuntimeError("You should run parse_maccabi_games first.")
+
+        self.maccabi_games_stats = run_general_fixes(self.maccabi_games_stats)
+
+    def _load_serialized_games(self):
+        """
+        Load the serialized games to self.maccabi_games_stats
+        :return: MaccabiGamesStats
+        """
+
+        with open(self._serialized_games_path, 'rb') as f:
+            return pickle.load(f)
+
+    def _serialize_games(self):
+        """
+        Serialize the parsed games (without any fixes).
+        """
+
+        if os.path.isfile(self._serialized_games_path):
+            # todo: bkup the old file
+            # old_file_path = Path(self._serialized_games_path)
+            # old_file_path.stem+= int(time())
+            pass
+
+        with open(self._serialized_games_path, 'wb') as f:
+            pickle.dump(self.maccabi_games_stats, f)
+

--- a/maccabistats/parse/merge_sources.py
+++ b/maccabistats/parse/merge_sources.py
@@ -1,0 +1,101 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+"""
+Merge all the sources to one maccabi games stats object, atm table source contains no events and we threat those games as verified content.
+"""
+
+
+def merge_maccabitlv_and_table(maccabitlv_site_source, table_source):
+    """
+    Merge All the sources to one maccabi games stats,
+    For each maccabitlv-site game find the matching table game and merge.
+    Ignoring (adding but nor merging) maccabi-tlv site games without matching table game.
+
+    :param maccabitlv_site_source: the maccabi games stats object from maccabitlv site source.
+    :type maccabitlv_site_source: maccabistats.stats.maccabi_games_stats.MaccabiGamesStats
+    :type table_source: maccabistats.stats.maccabi_games_stats.MaccabiGamesStats
+    :param table_source: the maccabi games stats object from table source.
+    :rtype: maccabistats.stats.maccabi_games_stats.MaccabiGamesStats
+    """
+
+    logger.info("Merging maccabitlv site and table sources")
+
+    # Table source supporting only league games.
+    maccabitlv_site_league_games = maccabitlv_site_source.get_first_league_games()
+
+    # We dont need to merge non-league games
+    merged_games = [game for game in maccabitlv_site_source if game not in maccabitlv_site_league_games]
+
+    for maccabitlv_site_game in maccabitlv_site_league_games:
+        matching_games = table_source.played_at(maccabitlv_site_game.date)
+
+        if len(matching_games) != 1:
+            logger.warning("Could not decide which game to take from this date: {date}, Found {num} games, adding them anyway"
+                           .format(date=maccabitlv_site_game.date, num=len(matching_games)))
+
+            # Atm, Add those games (1 or more).
+            if len(matching_games) > 0:
+                merged_games.extend(matching_games)
+            else:
+                merged_games.append(maccabitlv_site_game)
+            continue
+
+        merged_games.append(__merge_two_games(matching_games[0], maccabitlv_site_game))  # Takes only the first game on this date.
+
+    return merged_games
+
+
+def __merge_two_games(table_game, maccabitlv_site_game):
+    """
+    Merging two matching games (by playing date).
+    :param maccabitlv_site_game: Game parsed from table source.
+    :type maccabitlv_site_game: maccabistats.models.game_data.GameData
+    :param table_game: Game parsed from maccabitlv site.
+    :type table_game: maccabistats.models.game_data.GameData
+    :rtype: maccabistats.models.game_data.GameData
+    """
+
+    logger.info(f"Merging games at date :{table_game.date}")
+    __override_general_game_details_from_table(maccabitlv_site_game, table_game)
+
+    # TODO - this might be in another function
+
+    # Check whether there is home-away mismatch:
+    if table_game.away_team.name == maccabitlv_site_game.home_team.name and table_game.home_team.name == maccabitlv_site_game.away_team.name:
+        logger.info(f"Found home-away mismatch - switching positions,"
+                    f" new home team: {maccabitlv_site_game.away_team.name}, new away team: {maccabitlv_site_game.home_team.name}")
+        maccabitlv_site_game.home_team, maccabitlv_site_game.away_team = maccabitlv_site_game.away_team, maccabitlv_site_game.home_team
+
+    if table_game.away_team.score != maccabitlv_site_game.away_team.score:
+        logger.info(f"Found diff - away team score: {table_game.away_team.score}(table) - {maccabitlv_site_game.away_team.score}(maccabitlv site)")
+        maccabitlv_site_game.away_team.score = table_game.away_team.score
+
+    if table_game.home_team.score != maccabitlv_site_game.home_team.score:
+        logger.info(f"Found diff - home team score: {table_game.home_team.score}(table) - {maccabitlv_site_game.home_team.score}(maccabitlv site)")
+        maccabitlv_site_game.home_team.score = table_game.home_team.score
+
+    return maccabitlv_site_game
+
+
+def __override_general_game_details_from_table(maccabitlv_site_game, table_game):
+    """
+    Take the table general game data and sets it at maccabitlv site game.
+    :param maccabitlv_site_game: Game parsed from table source.
+    :type maccabitlv_site_game: maccabistats.models.game_data.GameData
+    :param table_game: Game parsed from maccabitlv site.
+    :type table_game: maccabistats.models.game_data.GameData
+    """
+
+    if table_game.referee != maccabitlv_site_game.referee:
+        logger.info(f"Found diff - referee: {table_game.referee}(table) - {maccabitlv_site_game.referee}(maccabitlv site)")
+        maccabitlv_site_game.referee = table_game.referee
+
+    if table_game.stadium != maccabitlv_site_game.stadium:
+        logger.info(f"Found diff - stadium: {table_game.stadium}(table) - {maccabitlv_site_game.stadium}(maccabitlv site)")
+        maccabitlv_site_game.stadium = table_game.stadium
+
+    if table_game.fixture != maccabitlv_site_game.fixture:
+        logger.info(f"Found dif - fixture: {table_game.fixture}(table) - {maccabitlv_site_game.fixture}(maccabitlv site)")
+        maccabitlv_site_game.fixture = table_game.fixture

--- a/maccabistats/parse/table/main_parser.py
+++ b/maccabistats/parse/table/main_parser.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+
+from pathlib import Path
+import json
+from dateutil.parser import parse as datetime_parser
+from maccabistats.models.game_data import GameData
+from maccabistats.models.team_in_game import TeamInGame
+
+root_folder = Path.home()
+
+# TODO: make that better (maybe from config).
+jsoned_games_path = root_folder / "maccabistats" / "sources" / "table-games.json"
+
+"""
+ Jsoned game format:
+
+        "referee": str,
+        "away_team": str,
+        "away_team_score": int,
+        "home_team_score": int,
+        "home_team": str,
+        "stadium": str,
+        "date": str date :"1955-02-05 00:00:00",
+        "fixture": int,
+        "season": str
+"""
+
+
+def get_jsoned_table_games():
+    with open(jsoned_games_path, 'rb') as f:
+        return json.load(f)
+
+
+def parse_to_maccabistats_game(jsoned_game):
+    """
+    Parse jsoned game to maccabistats game format (GameData).
+    :param jsoned_game: the game to parse.
+    :type jsoned_game: dict
+    :return: maccabistats.models.game_data.GameData
+    """
+
+    home_team = TeamInGame(jsoned_game['home_team'], None, jsoned_game['home_team_score'], [])
+    away_team = TeamInGame(jsoned_game['away_team'], None, jsoned_game['away_team_score'], [])
+    date = datetime_parser(jsoned_game['date'])
+    is_maccabi_home_team = True if home_team.name == "מכבי תא" else False
+    game = GameData("ליגת העל", jsoned_game["fixture"], "", jsoned_game["stadium"], "", jsoned_game["referee"], home_team, away_team,
+                    is_maccabi_home_team, jsoned_game["season"], [], date)
+
+    return game
+
+
+def get_parsed_maccabi_games_from_json():
+    jsoned_table_games = get_jsoned_table_games()
+
+    maccabistats_format_games = [parse_to_maccabistats_game(game) for game in jsoned_table_games]
+
+    return maccabistats_format_games

--- a/maccabistats/parse/table/table_source.py
+++ b/maccabistats/parse/table/table_source.py
@@ -1,0 +1,36 @@
+import logging
+from maccabistats.parse.maccabistats_source import MaccabiStatsSource
+from maccabistats.parse.table.main_parser import get_parsed_maccabi_games_from_json
+
+logger = logging.getLogger(__name__)
+
+"""
+Table is external source which saves maccabi games as json
+"""
+
+
+class TableSource(MaccabiStatsSource):
+
+    def parse_maccabi_games(self, without_rerunning=False):
+        """
+        Parse the raw data and saves it on self.maccabi_games_stats.
+
+        :param without_rerunning: whether this source should be rerun or just use the serialized object.
+        """
+
+        super().parse_maccabi_games(without_rerunning=False)
+
+    def _rerun_source(self):
+        """
+        Parse the raw data and saves it on self.maccabi_games_stats
+        """
+
+        return get_parsed_maccabi_games_from_json()
+
+    def run_specific_fixes(self):
+        """
+        Run any specific fixes for this source (such as error within the raw data).
+        """
+
+        logger.info("ATM, there are not specific fixes for table source")
+

--- a/maccabistats/stats/maccabi_games_stats.py
+++ b/maccabistats/stats/maccabi_games_stats.py
@@ -15,6 +15,7 @@ from maccabistats.stats.graphs import MaccabiGamesGraphsStats
 from maccabistats.version import version as maccabistats_version
 
 from dateutil.parser import parse as datetime_parser
+import datetime
 
 
 class MaccabiGamesStats(object):
@@ -104,11 +105,13 @@ class MaccabiGamesStats(object):
         """
         Currently checking just the: year & month & day.
         :param date: datetime.datetime or str
-        :return: maccabistats.models.game_data.GameData
+        :rtype: list of maccabistats.models.game_data.GameData
         """
 
         if type(date) is str:
             date = datetime_parser(date).date()
+        elif type(date) is datetime.datetime:
+            date = date.date()  # Leave only year & month & day
 
         return [game for game in self.games if game.date.date() == date]
 

--- a/maccabistats/stats/serialized_games.py
+++ b/maccabistats/stats/serialized_games.py
@@ -1,18 +1,26 @@
 # -*- coding: utf-8 -*-
 
 from maccabistats.stats.maccabi_games_stats import MaccabiGamesStats
-from maccabistats.parse.parse_from_all_sites import parse_maccabi_games_from_all_sites
+from maccabistats.parse.parse_from_all_sites import parse_maccabi_games_from_all_sources
 
 import pickle
 import os
+import glob
+import datetime
+import logging
 
-serialized_maccabi_games_folder_path = os.path.dirname(os.path.abspath(__file__))
-serialized_maccabi_games_file_name = "maccabi.games"
-serialized_maccabi_games_file_path = os.path.join(serialized_maccabi_games_folder_path,
-                                                  serialized_maccabi_games_file_name)
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_maccabistats_root_folder_path = Path.home().as_posix()
+_serialized_maccabi_games_folder_path = os.path.join(_maccabistats_root_folder_path, "maccabistats")
+_serialized_maccabi_games_file_name_pattern = "maccabi-{version}-{date}.games"
+_serialized_maccabi_games_file_path_pattern = os.path.join(_serialized_maccabi_games_folder_path,
+                                                           _serialized_maccabi_games_file_name_pattern)
 
 
-def get_maccabi_stats_as_newest_wrapper(file_name=serialized_maccabi_games_file_path):
+def get_maccabi_stats_as_newest_wrapper(file_name=None):
     """"
     Returns the serialized file_name cast to the latest MaccabiGamesStats object, which means that newer functions can be used.
     """
@@ -20,38 +28,60 @@ def get_maccabi_stats_as_newest_wrapper(file_name=serialized_maccabi_games_file_
     return MaccabiGamesStats(get_maccabi_stats(file_name).games)
 
 
-def get_maccabi_stats(file_name=serialized_maccabi_games_file_path):
+def get_maccabi_stats(file_name=None):
     """
     :param file_name: pickled maccabi games (probably MaccabiGamesStats object).
+                      When no file is given, Try to load the latest maccabi*.games from the default folder.
     :rtype: MaccabiGamesStats
     """
 
-    if not os.path.isfile(file_name):
-        raise RuntimeError("You should have maccabi.games serialized object, you can use maccabistats.serialize_maccabi_games() to do that.")
+    if not file_name:
+        maccabi_games_files_in_default_folder = glob.glob(_serialized_maccabi_games_file_path_pattern.format(version="*", date="*"))
+        if not maccabi_games_files_in_default_folder:
+            raise RuntimeError(
+                f"No file name was given -> Failed to get the latest maccabi*.games from default folder: {_serialized_maccabi_games_folder_path}")
+        file_name = maccabi_games_files_in_default_folder[-1]
+
+    else:
+        if not os.path.isfile(file_name):
+            raise RuntimeError("You should have maccabi.games serialized object, you can use maccabistats.serialize_maccabi_games() to do that.")
 
     with open(file_name, 'rb') as f:
+        logger.info(f"Loading maccabi games from {file_name}")
         return pickle.load(f)
 
 
-def serialize_maccabi_games(file_name=serialized_maccabi_games_file_path):
+def combine_maccabi_stats_sources():
     """
-    :param file_name: pickled maccabi games path.
+    Combine all the serialized object from all sources to one maccabi games stats objects, this function should be fast - without rerunning sources.
+    :return: MaccabiGamesStats
     """
 
-    maccabi_games = parse_maccabi_games_from_all_sites()
-    with open(file_name, 'wb') as f:
-        pickle.dump(maccabi_games, f)
+    return parse_maccabi_games_from_all_sources(without_rerunning=True)
 
 
-def reserialize_maccabi_games(maccabi_games_stats, file_name=serialized_maccabi_games_file_path):
+def run_all_maccabi_stats_sources():
+    """
+    Runs all the sources  - does not use the serialized objects is there are any.
+    :return: MaccabiGamesStats
+    """
+
+    return parse_maccabi_games_from_all_sources()
+
+
+def serialize_maccabi_games(maccabi_games_stats, folder_path=_serialized_maccabi_games_folder_path):
     """
     Reserialize maccabi games stats, after doing manually manipulation (run_manual_fixes) or anything else.
     :type maccabi_games_stats: maccabistats.stats.maccabi_games_stats.MaccabiGamesStats
-    :param file_name: path to pickle maccabi game at
+    :param folder_path: Folder path to pickle maccabi game at
     """
 
     if not isinstance(maccabi_games_stats, MaccabiGamesStats):
         raise RuntimeError("You Should serialize only maccabi games stats object")
 
+    file_name = os.path.join(folder_path, _serialized_maccabi_games_file_name_pattern).format(version=maccabi_games_stats.version,
+                                                                                              date=str(datetime.date.today()))
     with open(file_name, 'wb') as f:
         pickle.dump(maccabi_games_stats, f)
+
+    logger.info(f"Serialized maccabi games to {file_name}")

--- a/maccabistats/test.py
+++ b/maccabistats/test.py
@@ -1,13 +1,9 @@
 # -*- coding: utf-8 -*-
 
 
-from maccabistats import *
+from maccabistats.stats.serialized_games import combine_maccabi_stats_sources
 
 if __name__ == "__main__":
 
-    g = get_maccabi_stats_as_newest_wrapper()
-
-    b = g.graphs.goals_distribution_for_player("ערן זהבי")
-    print(b[0:10])
-
+    g = combine_maccabi_stats_sources()
     a = 6

--- a/maccabistats/version.py
+++ b/maccabistats/version.py
@@ -1,1 +1,1 @@
-version = "1.10.2"
+version = "2.0.0"


### PR DESCRIPTION
removed run_manual_Fixes from parse_all_sites

Parsing is working with the new architecture for combining sources (just with one source, and without doc).

parse table source as well, without merging atm

fix opponents names from table source

Merging works!

run general fixes after merge

 renamed table json file

renamed merge_cources to more be specific

Add Doc

fix hapoel_haifa_game at maccbai-tlv site

merge only league games between maccabitlv site and table

Moved all folders under "..users\(current_user)\maccabistats".

Adapt load&serialize to the new hierarchy.

moved tavla jsoned also

changed the docs according to new changes

Fix bug when non league games werent merged, Increase version to 2

logs

tavla-table