### PR TITLE
feat: add 3 new ErrorsFinder checks (v2.53)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 2.53 ##
+
+    Add 3 new ErrorsFinder checks: sub-out without playing, same player on both teams, duplicate events
+
 ## Version 2.52 ##
 
     Ignore EventType=13 (display-only events) from MaccabiPedia parser

--- a/src/maccabistats/error_finder/error_finder.py
+++ b/src/maccabistats/error_finder/error_finder.py
@@ -283,9 +283,7 @@ class ErrorsFinder:
         players_and_games = []
         for game in self.maccabi_games_stats:
             for player in game.maccabi_team.players:
-                if (player.has_event_type(GameEventTypes.SUBSTITUTION_OUT)
-                        and not player.has_event_type(GameEventTypes.LINE_UP)
-                        and not player.has_event_type(GameEventTypes.SUBSTITUTION_IN)):
+                if player.has_event_type(GameEventTypes.SUBSTITUTION_OUT) and not player.played_in_game:
                     players_and_games.append((player.name, game))
         return players_and_games
 

--- a/src/maccabistats/error_finder/error_finder.py
+++ b/src/maccabistats/error_finder/error_finder.py
@@ -275,6 +275,50 @@ class ErrorsFinder:
 
         return players_and_games
 
+    def get_players_with_substitution_out_but_never_played(self) -> List[Tuple[str, GameData]]:
+        """
+        Players that have a substitution-out event but never appeared in the lineup or came on as a sub.
+        This indicates a data entry error on the wiki.
+        """
+        players_and_games = []
+        for game in self.maccabi_games_stats:
+            for player in game.maccabi_team.players:
+                if (player.has_event_type(GameEventTypes.SUBSTITUTION_OUT)
+                        and not player.has_event_type(GameEventTypes.LINE_UP)
+                        and not player.has_event_type(GameEventTypes.SUBSTITUTION_IN)):
+                    players_and_games.append((player.name, game))
+        return players_and_games
+
+    def get_games_with_same_player_on_both_teams(self) -> List[Tuple[str, GameData]]:
+        """
+        Games where the same player name appears on both Maccabi and the opponent team.
+        Usually indicates a naming collision or a data entry error.
+        """
+        results = []
+        for game in self.maccabi_games_stats:
+            maccabi_names = {p.name for p in game.maccabi_team.players}
+            opponent_names = {p.name for p in game.not_maccabi_team.players}
+            for name in maccabi_names & opponent_names:
+                results.append((name, game))
+        return results
+
+    def get_players_with_duplicate_events(self) -> List[Tuple[str, GameData]]:
+        """
+        Players that have two or more identical events (same type + same minute) in the same game.
+        Indicates a duplicate entry on the wiki.
+        """
+        results = []
+        for game in self.maccabi_games_stats:
+            for player in game.maccabi_team.players:
+                seen = set()
+                for event in player.events:
+                    key = (event.event_type, event.time_occur)
+                    if key in seen:
+                        results.append((player.name, game))
+                        break
+                    seen.add(key)
+        return results
+
     def get_all_errors_numbers(self):
         """ Iterate over all this class functions without this one, and summarize the results. """
         errors_finders = [func for func in dir(self) if

--- a/src/maccabistats/version.py
+++ b/src/maccabistats/version.py
@@ -1,1 +1,1 @@
-version = "2.52"
+version = "2.53"


### PR DESCRIPTION
## Summary
- `get_players_with_substitution_out_but_never_played` — player has sub-out but no lineup/sub-in entry
- `get_games_with_same_player_on_both_teams` — same name appears on both Maccabi and opponent
- `get_players_with_duplicate_events` — same player has identical event type+minute twice in one game

Bump version to 2.53, changelog updated.

## Test plan
- [ ] Run `ErrorsFinder.get_all_errors_numbers()` against live MaccabiPedia data and verify the 3 new checks appear and return expected results (1, 11, 0 respectively based on current data)

🤖 Generated with [Claude Code](https://claude.com/claude-code)